### PR TITLE
test for activemodel instead of rails for activemodel validations

### DIFF
--- a/lib/couchbase/model.rb
+++ b/lib/couchbase/model.rb
@@ -811,7 +811,7 @@ module Couchbase
 
     protected :attributes_with_values
 
-    if defined?(::Rails)
+    if defined?(::ActiveModel)
       extend ActiveModel::Callbacks
       extend ActiveModel::Naming
       include ActiveModel::Conversion


### PR DESCRIPTION
There's a lot of use-cases where ActiveModel gets used without
including the full rails stack. Since nothing in activemodel validations
depends on rails, we can just test if activemodel is available before
including it, instead of testing for rails.
